### PR TITLE
Modify `quickcheck::Arbitrary` implementation of `TokenAmount` due to `BigInt` serialization limit

### DIFF
--- a/shared/src/econ/mod.rs
+++ b/shared/src/econ/mod.rs
@@ -117,7 +117,8 @@ impl quickcheck::Arbitrary for TokenAmount {
         // a value of 128; need to constrain the corresponding length during
         // `Arbitrary` generation of `BigInt` in `TokenAmount` to below
         // MAX_BIGINT_SIZE.
-        TokenAmount::from_atto(BigInt::arbitrary(g) % (1 << (crate::bigint::MAX_BIGINT_SIZE * 8)))
+        let bigint_upper_ceiling = (1 << ((crate::bigint::MAX_BIGINT_SIZE - 1) * 8));
+        TokenAmount::from_atto(BigInt::arbitrary(g) % bigint_upper_ceiling)
     }
 }
 

--- a/shared/src/econ/mod.rs
+++ b/shared/src/econ/mod.rs
@@ -111,7 +111,13 @@ impl fmt::Debug for TokenAmount {
 #[cfg(feature = "arb")]
 impl quickcheck::Arbitrary for TokenAmount {
     fn arbitrary(g: &mut quickcheck::Gen) -> Self {
-        TokenAmount::from_atto(BigInt::arbitrary(g))
+        // During serialization/deserialization, permissible length of the byte
+        // representation (plus a leading positive sign byte for non-zero
+        // values) of BigInts is currently set to a max of MAX_BIGINT_SIZE with
+        // a value of 128; need to constrain the corresponding length during
+        // `Arbitrary` generation of `BigInt` in `TokenAmount` to below
+        // MAX_BIGINT_SIZE.
+        TokenAmount::from_atto(BigInt::arbitrary(g) % 10)
     }
 }
 

--- a/shared/src/econ/mod.rs
+++ b/shared/src/econ/mod.rs
@@ -117,8 +117,8 @@ impl quickcheck::Arbitrary for TokenAmount {
         // a value of 128; need to constrain the corresponding length during
         // `Arbitrary` generation of `BigInt` in `TokenAmount` to below
         // MAX_BIGINT_SIZE.
-        let bigint_upper_ceiling = (BigInt::from(1) << ((crate::bigint::MAX_BIGINT_SIZE - 1) * 8));
-        TokenAmount::from_atto(BigInt::arbitrary(g) % bigint_upper_ceiling)
+        let bigint_upper_limit = (BigInt::from(1) << ((crate::bigint::MAX_BIGINT_SIZE - 1) * 8));
+        TokenAmount::from_atto(BigInt::arbitrary(g) % bigint_upper_limit)
     }
 }
 

--- a/shared/src/econ/mod.rs
+++ b/shared/src/econ/mod.rs
@@ -117,7 +117,7 @@ impl quickcheck::Arbitrary for TokenAmount {
         // a value of 128; need to constrain the corresponding length during
         // `Arbitrary` generation of `BigInt` in `TokenAmount` to below
         // MAX_BIGINT_SIZE.
-        let bigint_upper_ceiling = (1 << ((crate::bigint::MAX_BIGINT_SIZE - 1) * 8));
+        let bigint_upper_ceiling = (BigInt::from(1) << ((crate::bigint::MAX_BIGINT_SIZE - 1) * 8));
         TokenAmount::from_atto(BigInt::arbitrary(g) % bigint_upper_ceiling)
     }
 }

--- a/shared/src/econ/mod.rs
+++ b/shared/src/econ/mod.rs
@@ -117,7 +117,7 @@ impl quickcheck::Arbitrary for TokenAmount {
         // a value of 128; need to constrain the corresponding length during
         // `Arbitrary` generation of `BigInt` in `TokenAmount` to below
         // MAX_BIGINT_SIZE.
-        TokenAmount::from_atto(BigInt::arbitrary(g) % 10)
+        TokenAmount::from_atto(BigInt::arbitrary(g)) % (1 << (MAX_BIGINT_SIZE * 8))
     }
 }
 

--- a/shared/src/econ/mod.rs
+++ b/shared/src/econ/mod.rs
@@ -117,7 +117,7 @@ impl quickcheck::Arbitrary for TokenAmount {
         // a value of 128; need to constrain the corresponding length during
         // `Arbitrary` generation of `BigInt` in `TokenAmount` to below
         // MAX_BIGINT_SIZE.
-        TokenAmount::from_atto(BigInt::arbitrary(g)) % (1 << (MAX_BIGINT_SIZE * 8))
+        TokenAmount::from_atto(BigInt::arbitrary(g) % (1 << (crate::bigint::MAX_BIGINT_SIZE * 8)))
     }
 }
 


### PR DESCRIPTION
The `BigInt` serialization in `fvm_shared` checks to make sure the length of the byte representation of the `BigInt` (plus a leading positive sign byte) is less than `MAX_BIGINT_SIZE`. Because of this limitation, the `TokenAmount` `quickcheck` test currently fails due to exceeding the `MAX_BIGINT_SIZE` limit when attempting to serialize/deserialize the arbitrary `BigInt` generated by `BigInt::arbitrary(g)`. This PR limits the size of the arbitrary `BigInt` generated for use in `TokenAmount`. This PR is associated with PR #[2591](https://github.com/ChainSafe/forest/pull/2591).